### PR TITLE
Improve key-value parsing (#100)

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -60,30 +60,64 @@ scanners:
     - positive:
         flavors:
           - 'application/msword'
-          - 'application/vnd.openxmlformats-officedocument'
-          - 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-          - 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-          - 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
           - 'olecf_file'
-          - 'ooxml_file'
-          - 'audio/mpeg'
-          - 'mp3_file'
-          - 'mhtml_file'
+          - 'application/vnd.ms-excel'
+      priority: 5
+      options:
+        keys:
+          - 'Author'
+          - 'Characters'
+          - 'Company'
+          - 'CreateDate'
+          - 'LastModifiedBy'
+          - 'Lines'
+          - 'ModifyDate'
+          - 'Pages'
+          - 'Paragraphs'
+          - 'RevisionNumber'
+          - 'Software'
+          - 'Template'
+          - 'Title'
+          - 'TotalEditTime'
+          - 'Words'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'application/pdf'
           - 'pdf_file'
-          - 'text/rtf'
-          - 'rtf_file'
-          - 'wordml_file'
-          - 'application/x-dosexec'
-          - 'mz_file'
-          - 'application/x-object'
-          - 'application/x-executable'
-          - 'application/x-sharedlib'
-          - 'application/x-coredump'
-          - 'elf_file'
+      priority: 5
+      options:
+        keys:
+          - 'Author'
+          - 'CreateDate'
+          - 'Creator'
+          - 'CreatorTool'
+          - 'Linearized'
+          - 'ModifyDate'
+          - 'PageCount'
+          - 'PDFVersion'
+          - 'Producer'
+          - 'Title'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'lnk_file'
-          - 'application/x-mach-binary'
-          - 'macho_file'
+      priority: 5
+      options:
+        keys:
+          - 'CommandLineArguments'
+          - 'Description'
+          - 'FileAttributes'
+          - 'Flags'
+          - 'HotKey'
+          - 'IconFileName'
+          - 'IconIndex'
+          - 'RunWindow'
+          - 'TargetFileSize'
+          - 'WorkingDirectory'
+        tmp_directory: '/dev/shm/'
+    - positive:
+        flavors:
           - 'image/gif'
           - 'gif_file'
           - 'image/jpeg'
@@ -96,15 +130,11 @@ scanners:
           - 'bmp_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
-          - 'psd_file'
-          - 'video/mp4'
-          - 'video/quicktime'
-          - 'video/x-msvideo'
-          - 'avi_file'
-          - 'video/x-ms-wmv'
-          - 'wmv_file'
       priority: 5
       options:
+        keys:
+          - 'ImageHeight'
+          - 'ImageWidth'
         tmp_directory: '/dev/shm/'
   'ScanGif':
     - positive:
@@ -151,6 +181,10 @@ scanners:
         flavors:
           - 'jar_manifest_file'
       priority: 5
+      options:
+        headers:
+          - 'Manifest-Version'
+          - 'Created-By'
   'ScanJavascript':
     - negative:
         flavors:

--- a/docs/README.md
+++ b/docs/README.md
@@ -501,7 +501,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanElf | Collects metadata from ELF files | N/A |
 | ScanEmail | Collects metadata and extract files from email messages | N/A |
 | ScanEntropy | Calculates entropy of files | N/A |
-| ScanExiftool | Collects metadata parsed by Exiftool | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/") |
+| ScanExiftool | Collects metadata parsed by Exiftool | "tempfile_directory" -- location where tempfile writes temporary files (defaults to "/tmp/")<br>"keys" -- list of keys to log (defaults to all) |
 | ScanFalconSandbox | Sends files to an instance of Falcon Sandbox | "server" -- URL of the Falcon Sandbox API inteface <br>"priority" -- Falcon Sandbox priority assigned to the task (defaults to 3)<br>"timeout" -- amount of time (in seconds) to wait for the task to upload (defaults to 60)<br>"envID" -- list of numeric envrionment IDs that tells Falcon Sandbox which sandbox to submit a sample to (defaults to [100])<br>"api_key" -- API key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_KEY")<br>"api_secret" --  API secret key used for authenticating to Falcon Sandbox (defaults to None, optionally read from environment variable "FS_API_SECKEY") |
 | ScanGif | Extracts data embedded in GIF files | N/A |
 | ScanGzip | Decompresses gzip files | N/A
@@ -524,7 +524,7 @@ The table below describes each scanner and its options. Each scanner has the hid
 | ScanPgp | Collects metadata from PGP files | N/A |
 | ScanPhp | Collects metadata from PHP files | N/A |
 | ScanPkcs7 | Extracts files from PKCS7 certificate files | N/A |
-| ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to ['Label']) |
+| ScanPlist | Collects attributes from binary and XML property list files | "keys" -- list of keys to log (defaults to all) |
 | ScanRar | Extracts files from RAR archives | "limit" -- maximum number of files to extract (defaults to 1000) |
 | ScanRpm | Collects metadata and extracts files from RPM files | "tempfile_directory" -- location where `tempfile` will write temporary files (defaults to "/tmp/") |
 | ScanRtf | Extracts embedded files from RTF files | "limit" -- maximum number of files to extract (defaults to 1000) |

--- a/src/python/strelka/scanners/scan_exiftool.py
+++ b/src/python/strelka/scanners/scan_exiftool.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import subprocess
 import tempfile
@@ -9,10 +10,13 @@ class ScanExiftool(strelka.Scanner):
     """Collects metadata parsed by Exiftool.
 
     Options:
+        keys: exiftool key values to log in the event.
+            Defaults to all.
         tmp_directory: Location where tempfile writes temporary files.
             Defaults to '/tmp/'.
     """
     def scan(self, data, file, options, expire_at):
+        keys = options.get('keys', [])
         tmp_directory = options.get('tmp_directory', '/tmp/')
 
         with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
@@ -27,10 +31,22 @@ class ScanExiftool(strelka.Scanner):
 
             if stdout:
                 exiftool_dictionary = json.loads(stdout)[0]
-                self.event.setdefault('exiftool', [])
-                for (key, value) in exiftool_dictionary.items():
-                    if isinstance(value, str):
-                        value = value.strip()
-                    exiftool_entry = {'field': key, 'value': value}
-                    if exiftool_entry not in self.event['exiftool']:
-                        self.event['exiftool'].append(exiftool_entry)
+
+                self.event['keys'] = []
+                for k, v in exiftool_dictionary.items():
+                    if keys and k not in keys:
+                        continue
+
+                    if isinstance(v, str):
+                        v = v.strip()
+                        v = v.strip('\'"')
+
+                        try:
+                            v = ast.literal_eval(v)
+                        except (ValueError, SyntaxError):
+                            pass
+
+                    self.event['keys'].append({
+                        'key': k,
+                        'value': v,
+                    })

--- a/src/python/strelka/scanners/scan_html.py
+++ b/src/python/strelka/scanners/scan_html.py
@@ -25,7 +25,7 @@ class ScanHtml(strelka.Scanner):
             soup = bs4.BeautifulSoup(data, parser)
 
             if soup.title:
-                self.event['title'] = strelka.normalize_whitespace(soup.title.text)
+                self.event['title'] = soup.title.text
 
             hyperlinks = []
             hyperlinks.extend(soup.find_all('a', href=True))

--- a/src/python/strelka/scanners/scan_jar_manifest.py
+++ b/src/python/strelka/scanners/scan_jar_manifest.py
@@ -1,18 +1,34 @@
+import ast
+
 from strelka import strelka
 
 
 class ScanJarManifest(strelka.Scanner):
     """Collects metadata from JAR manifest files."""
     def scan(self, data, file, options, expire_at):
+        headers = options.get('headers', [])
+
         manifest = b'\n'.join(data.splitlines()).rstrip(b'\n')
         section_strings = manifest.split(b'\n')
-        self.event.setdefault('manifest', [])
+
+        self.event['headers'] = []
         for section in section_strings:
-            split_section = section.replace(b'\n ', b'').split(b': ')
-            if len(split_section) == 2:
-                jar_entry = {
-                    'header': split_section[0],
-                    'value': split_section[1],
-                }
-                if jar_entry not in self.event['manifest']:
-                    self.event['manifest'].append(jar_entry)
+            s = section.replace(b'\n', b'').split(b':')
+            if len(s) == 2:
+                h, v = s[0].strip(), s[1].strip()
+
+                if h not in self.event['headers']:
+                    self.event['headers'].append(h)
+
+                if headers and h not in headers:
+                    continue
+
+                try:
+                    v = ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    pass
+
+                self.event['headers'].append({
+                    'header': h,
+                    'value': v,
+                })

--- a/src/python/strelka/scanners/scan_pe.py
+++ b/src/python/strelka/scanners/scan_pe.py
@@ -307,7 +307,7 @@ class ScanPe(strelka.Scanner):
             'checksum': pe.OPTIONAL_HEADER.CheckSum,
             'machine': {
                 'id': pe.FILE_HEADER.Machine,
-                'type': pefile.MACHINE_TYPE.get(pe.FILE_HEADER.Machine).replace('IMAGE_FILE_', ''),
+                'type': pefile.MACHINE_TYPE.get(pe.FILE_HEADER.Machine).replace('IMAGE_FILE_MACHINE_', ''),
             },
             'magic': {
                 'dos': MAGIC_DOS.get(pe.DOS_HEADER.e_magic, ''),

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -16,8 +16,8 @@ class ScanYara(strelka.Scanner):
     Options:
         location: Location of the YARA rules file or directory.
             Defaults to '/etc/yara/'.
-        metadata_identifiers: List of YARA rule metadata identifiers
-            (e.g. 'Author') that should be logged as metadata.
+        meta: List of YARA rule meta identifiers
+            (e.g. 'Author') that should be logged.
             Defaults to empty list.
     """
     def init(self):
@@ -25,7 +25,7 @@ class ScanYara(strelka.Scanner):
 
     def scan(self, data, file, options, expire_at):
         location = options.get('location', '/etc/yara/')
-        metadata_identifiers = options.get('metadata_identifiers', [])
+        meta = options.get('meta', [])
 
         try:
             if self.compiled_yara is None:
@@ -42,24 +42,24 @@ class ScanYara(strelka.Scanner):
         except (yara.Error, yara.SyntaxError):
             self.flags.append('compiling_error')
 
-        self.event.setdefault('matches', [])
-        self.event.setdefault('metadata', [])
+        self.event['matches'] = []
+        self.event['meta'] = []
 
         try:
             if self.compiled_yara is not None:
                 yara_matches = self.compiled_yara.match(data=data)
                 for match in yara_matches:
                     self.event['matches'].append(match.rule)
-                    if metadata_identifiers and match.meta:
-                        for (key, value) in match.meta.items():
-                            if key in metadata_identifiers:
-                                yara_entry = {
-                                    'rule': match.rule,
-                                    'identifier': key,
-                                    'value': value,
-                                }
-                                if yara_entry not in self.event['metadata']:
-                                    self.event['metadata'].append(yara_entry)
+
+                    for k, v in match.meta.items():
+                        if meta and k not in meta:
+                            continue
+
+                        self.event['meta'].append({
+                            'rule': match.rule,
+                            'identifier': k,
+                            'value': v,
+                        })
 
         except (yara.Error, yara.TimeoutError):
             self.flags.append('scanning_error')


### PR DESCRIPTION
* Remove binary plist from Exiftool

This commit removes binary plist files from Exiftool parsing — this is replaced by ScanPlist.

* Modify Exiftool logging

This commit modifies the logging of exiftool so that it no longer logs all key-values in an array; instead, the key-values are logged as entries in the dictionary and the keys to log are user-configurable. ScanPlist was refactored to mimic this behavior.

* Fix looping errors

pass is not the same as continue

* Update Exiftool logging

Exiftool logging is now properly scoped to specific flavors and event keys.

* Refactor key-value parsing

This commit changes key-value parsing to allow for user-defined list of keys to log. If a user-defined list is missing, then all key-values will be logged. This does not apply to ScanIni because an INI file is not representative of a true key-value pair.

* Fixed meta option

* Remove ‘Label’ as the default key

* Remove key-value string stripping

* Fix replacement on machine.type

* Testing increased PoolSize

* Remove hard-coded PoolSize

**Describe the change**
Include a summary of the change (with required dependencies), any issues it fixes, and relevant motivation and context.

**Describe testing procedures**
Describe the tests that you ran to verify your changes (including test configurations) and instructions so we can reproduce the tests. To assist in testing, the project maintainers may ask for file samples.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
